### PR TITLE
Fixed some errors with HDP usage

### DIFF
--- a/hdfs_datanode.py
+++ b/hdfs_datanode.py
@@ -117,10 +117,11 @@ class DataNodeMetricCollector(MetricCollector):
                     for k, v in volume_info_dict.items():
                         path = k
                         for key, val in v.items():
-                            state = key
-                            label = [self.cluster, version, path, state, self.target]
-                            value = val
-                            self.hadoop_datanode_metrics['DataNodeInfo'][metric].add_metric(label, value)
+                            if key != "storageType":
+                                state = key
+                                label = [self.cluster, version, path, state, self.target]
+                                value = val
+                                self.hadoop_datanode_metrics['DataNodeInfo'][metric].add_metric(label, value)
                 else:
                     continue
             else:

--- a/hdfs_journalnode.py
+++ b/hdfs_journalnode.py
@@ -37,14 +37,14 @@ class JournalNodeMetricCollector(MetricCollector):
                 if 'tag.Hostname' in beans[i]:
                     self.target = beans[i]["tag.Hostname"]
                     break
-            self.hadoop_datanode_metrics.update(self.common_metric_collector.get_metrics(beans, self.target))
+            self.hadoop_journalnode_metrics.update(self.common_metric_collector.get_metrics(beans, self.target))
             self.get_metrics(beans)
 
         for i in range(len(self.merge_list)):
             service = self.merge_list[i]
             if service in self.hadoop_journalnode_metrics:
-                for metric in self.hadoop_datanode_metrics[service]:
-                    yield self.hadoop_datanode_metrics[service][metric]
+                for metric in self.hadoop_journalnode_metrics[service]:
+                    yield self.hadoop_journalnode_metrics[service][metric]
 
     def setup_journalnode_labels(self):
         a_60_latency_flag, a_300_latency_flag, a_3600_latency_flag = 1, 1, 1

--- a/hdfs_journalnode.py
+++ b/hdfs_journalnode.py
@@ -126,7 +126,8 @@ class JournalNodeMetricCollector(MetricCollector):
                             a_3600_sum += beans[i][metric]
                     else:
                         key = metric
-                        self.hadoop_journalnode_metrics['JournalNode'][key].add_metric(label, beans[i][metric])
+                        if key in self.hadoop_journalnode_metrics['JournalNode']:
+                            self.hadoop_journalnode_metrics['JournalNode'][key].add_metric(label, beans[i][metric])
                 a_60_bucket = zip(a_60_percentile, a_60_value)
                 a_300_bucket = zip(a_300_percentile, a_300_value)
                 a_3600_bucket = zip(a_3600_percentile, a_3600_value)


### PR DESCRIPTION
Hi @opsnull , very thanks for the tool!

Testing on HDP3.1.4 and catch errors:

1. https://github.com/opsnull/hadoop_jmx_exporter/commit/bab8ef029ed6c0ab59665b765dd9d477483546e7
```
...
  File "/exporter/hdfs_journalnode.py", line 40, in collect
    self.hadoop_datanode_metrics.update(self.common_metric_collector.get_metrics(beans, self.target))
AttributeError: 'JournalNodeMetricCollector' object has no attribute 'hadoop_datanode_metrics' 
```

2.  https://github.com/opsnull/hadoop_jmx_exporter/commit/8bf3bbb7822ae38a75ecc11ac15b08c08264f8ca
```
  File "/exporter/hdfs_journalnode.py", line 129, in get_metrics
    self.hadoop_journalnode_metrics['JournalNode'][key].add_metric(label, beans[i][metric])
KeyError: u'NumEditLogsSynced'
```

3. https://github.com/opsnull/hadoop_jmx_exporter/commit/0e1cedea3e4c9f9b38db5f2032e975cc1e0d64b5
```
File "/usr/local/lib/python2.7/site-packages/prometheus_client/utils.py", line 9, in floatToGoString 
  d = float(d) ValueError: ('could not convert string to float: DISK', Metric(hadoop_hdfs_datanode_volume_state, Volume infomation in each path and in each mode, gauge, 
  ...
  Sample(
        name='hadoop_hdfs_datanode_volume_state', 
        labels={
            'cluster': 'cluster_name', 
            'state': 'storageType', 
            'version': u'3.1.1.3.1.4.0-315, r58d0fd3d8ce58b10149da3c717c45e5e57a60d14', 
            '_target': u'my.host.com', 
            'path': '/data'
        }, 
        value='DISK',  <---
        timestamp=None, 
        exemplar=None), 
 ...
```



