### PR TITLE
fix QueueMetrics finder

### DIFF
--- a/yarn_resourcemanager.py
+++ b/yarn_resourcemanager.py
@@ -247,7 +247,7 @@ class ResourceManagerMetricCollector(MetricCollector):
         for i in range(len(beans)):
             if 'RMNMInfo' in beans[i]['name']:
                 self.get_rmnminfo_metrics(beans[i])
-            if 'QueueMetrics' in beans[i]['name'] and re.match(self.queue_regexp, beans[i]['tag.Queue']):
+            if 'name=QueueMetrics' in beans[i]['name'] and re.match(self.queue_regexp, beans[i]['tag.Queue']):
                 self.get_queue_metrics(beans[i])
             if 'ClusterMetrics' in beans[i]['name']:
                 self.get_cluster_metrics(beans[i])


### PR DESCRIPTION
Hello
In vanila apache hadoop 3.3.2 bug is with queues. If use "name=QueueMetrics" for filter, all works fine.