### PR TITLE
suit for hostname witten in /etc/hosts in private cluster

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -4,6 +4,7 @@
 import threading
 import requests
 
+import utils
 from utils import get_module_logger
 
 
@@ -21,6 +22,8 @@ class Scraper(threading.Thread):
         result = []
         try:
             s = requests.session()
+            s.verify = utils.verify
+            s.trust_env = utils.trust_env
             response = s.get(self.url, timeout=5)
         except Exception as e:
             logger.warning("Get {0} failed, error: {1}.".format(self.url, str(e)))

--- a/utils.py
+++ b/utils.py
@@ -6,6 +6,9 @@ import argparse
 import logging
 import yaml
 
+verify = True
+trust_env = True
+
 
 def get_module_logger(mod_name):
     logger = logging.getLogger(mod_name)
@@ -67,4 +70,10 @@ def parse_args():
     parser.add_argument('-jns', required=False, metavar='journalnode_jmx_url', help='Hadoop journalnode jmx metrics URL.', nargs="*")
     parser.add_argument('-host', required=False, metavar='host', help='Listen on this address. default: 0.0.0.0', default='0.0.0.0')
     parser.add_argument('-port', required=False, metavar='port', type=int, help='Listen to this port. default: 6688', default=6688)
-    return parser.parse_args()
+    parser.add_argument('-verify', required=False, metavar='verify', help='Scrape veirify switch. default: True', default='True')
+    parser.add_argument('-trust', required=False, metavar='trust', help='Scrape trust env switch. default: True', default='True')
+    args = parser.parse_args()
+    global verify, trust_env
+    verify = args.verify == 'True'
+    trust_env = args.trust == 'True'
+    return args


### PR DESCRIPTION
add switch to compatible in private cluster

in our cluster, hostname was written in /etc/hosts, but requests session wont't recognize it.

Add command switch to control wheter use trust or verify in requests session.

If you wanna disable trust or verify in requests session, you could run like this 

`python2 hadoop_jmx_exporter.py   -cluster demo -port 12000 -rms http://office001111:8088/jmx -verify False -trust False`

![image](https://user-images.githubusercontent.com/11908411/179731818-7a72ff20-80d3-4533-b699-34e99f449e27.png)

It works fine!!!

Otherwise, you could run in older way to active the trust and verify option in requests session

` python2 hadoop_jmx_exporter.py   -cluster demo -port 12000 -rms http://office001111:8088/jmx `
![image](https://user-images.githubusercontent.com/11908411/179731173-c1ddc1bd-34c7-4a1e-8465-3577e71d4471.png)



Signed-off-by: kom0055 <ev.sin@hotmail.com>